### PR TITLE
Allows per table replication tie breaker column

### DIFF
--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -243,6 +243,17 @@ class PostgresStream(SQLStream):
         return state_value, None
     
     def _get_id_column_name(self) -> str:
+        """Get the tie-breaker column name for this stream.
+        
+        Checks for stream-specific override first, then falls back to global setting,
+        then defaults to 'id'.
+        """
+        # Check for stream-specific override
+        per_stream_config = self.config.get("replication_tie_breaker_columns", {})
+        if self.name in per_stream_config:
+            return per_stream_config[self.name] or 'id'
+        
+        # Fall back to global setting or default
         return self.config.get("replication_tie_breaker_column") or 'id'
     
     def _get_id_column(self, table) -> sa.Column:

--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -363,7 +363,17 @@ class TapPostgres(SQLTap):
             "replication_tie_breaker_column",
             th.StringType,
             description=(
-                "Optional column to use as a tie breaker when filtering records to avoid infinite loops"
+                "Optional column to use as a tie breaker when filtering records to avoid infinite loops. "
+                "This is the default for all streams. Use replication_tie_breaker_columns for per-stream overrides."
+            ),
+        ),
+        th.Property(
+            "replication_tie_breaker_columns",
+            th.ObjectType(),
+            description=(
+                "Optional per-stream tie breaker columns to override the default. "
+                "Format: {\"stream_name\": \"column_name\"}. "
+                "Example: {\"public-trip_items\": \"trip_item_id\", \"public-blocks\": \"block_uuid\"}"
             ),
         ),
         th.Property(


### PR DESCRIPTION
to support fixed route which has tables that doesn't have an `id` column